### PR TITLE
Implement MISP Object support (fix #17)

### DIFF
--- a/misp_test.py
+++ b/misp_test.py
@@ -393,5 +393,73 @@ class MispTransportErrorTest(unittest.TestCase):
         self.assertEquals(err.args[2], 404)
 
 
+class MispObjectTest(unittest.TestCase):
+    def test_from_xml(self):
+        xml = """<Object>
+    <id>1234</id>
+    <name>file</name>
+    <meta-category>file</meta-category>
+    <description>File object describing a file with meta-information</description>
+    <template_uuid>688c46fb-5edb-40a3-8273-1af7923e2215</template_uuid>
+    <template_version>13</template_version>
+    <event_id>9876</event_id>
+    <uuid>5c9c8b6f-bb24-4e6c-ab83-18c60a3a5cf9</uuid>
+    <timestamp>1553763183</timestamp>
+    <distribution>1</distribution>
+    <sharing_group_id>0</sharing_group_id>
+    <comment>Hello</comment>
+    <deleted>0</deleted>
+    <ObjectReference/>
+    <Attribute>
+      <id>2640682</id>
+      <type>malware-sample</type>
+      <category>Payload installation</category>
+      <to_ids>1</to_ids>
+      <uuid>5c9c8b70-4814-493b-a891-18c60a3a5cf9</uuid>
+      <event_id>14584</event_id>
+      <distribution>1</distribution>
+      <timestamp>1553763184</timestamp>
+      <comment/>
+      <sharing_group_id>0</sharing_group_id>
+      <deleted>0</deleted>
+      <disable_correlation>0</disable_correlation>
+      <object_id>292731</object_id>
+      <object_relation>malware-sample</object_relation>
+      <value>/tmp/a.exe|d41d8cd98f00b204e9800998ecf8427e</value>
+      <Galaxy/>
+      <data>abcdef</data>
+      <ShadowAttribute/>
+    </Attribute>
+    <Attribute>
+      <id>2640683</id>
+      <type>filename</type>
+      <category>Payload installation</category>
+      <to_ids>0</to_ids>
+      <uuid>5c9c8b73-0418-474f-a2ee-18c60a3a5cf9</uuid>
+      <event_id>14584</event_id>
+      <distribution>1</distribution>
+      <timestamp>1553763187</timestamp>
+      <comment/>
+      <sharing_group_id>0</sharing_group_id>
+      <deleted>0</deleted>
+      <disable_correlation>0</disable_correlation>
+      <object_id>292731</object_id>
+      <object_relation>filename</object_relation>
+      <value>/tmp/a.exe</value>
+      <Galaxy/>
+      <ShadowAttribute/>
+    </Attribute>
+  </Object>"""
+    
+        obj = MispObject.from_xml(xml)
+        self.assertEquals(obj.id, 1234)
+        self.assertEquals(obj.name, "file")
+        self.assertEquals(obj.comment, "Hello")
+        self.assertEquals(obj.event_id, 9876)
+        self.assertEquals(obj.timestamp, 1553763183)
+        self.assertEquals(obj.meta_category, "file")
+        self.assertEquals(len(obj.attributes), 2)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/mispy/misp.py
+++ b/mispy/misp.py
@@ -234,7 +234,7 @@ class MispTag(MispBaseObject):
 class MispObject(MispBaseObject):
     class Attributes(object):
         """
-        The module that provides glue between :class:`MispEvent` and :class:`MispAttribute`
+        The module that provides glue between :class:`MispObject` and :class:`MispAttribute`
 
         """
         def __init__(self, obj):
@@ -248,17 +248,6 @@ class MispObject(MispBaseObject):
             the attribute object (timestamp, uuid, event id).
 
             :param attr: a :class:`MispAttribute`'s instance to be added to the Object
-
-            :example:
-
-            >>> new_attr = MispAttribute()
-            >>> new_attr.value = 'foobar.com'
-            >>> new_attr.category = 'Network activity'
-            >>> new_attr.type = 'domain'
-            >>> server = MispServer()
-            >>> event = server.events.get(12)
-            >>> event.attributes.add(new_attr)
-            >>> server.events.update(event)
 
             """
             if type(attr) is not MispAttribute:
@@ -407,6 +396,24 @@ class MispObject(MispBaseObject):
                 obj.shadowattributes.append(shadowattribute_obj)
 
         return obj
+    
+    def to_xml_object(self):
+        obj = objectify.Element("Object")
+        for field in ['id', 'event_id', 'name', 'description', 'comment', 'timestamp']:
+            value = getattr(self, field)
+            setattr(obj, field, value)
+        setattr(obj, "meta-category", self.meta_category)
+
+        for attr in self.attributes:
+            attr_xml = attr.to_xml_object()
+            obj.append(attr_xml)
+        
+        for shadow in self.shadowattributes:
+            shadow_xml = shadow.to_xml_object()
+            obj.append(shadow_xml)
+        
+        return obj
+
 
 class MispEvent(MispBaseObject):
     class Attributes(object):
@@ -711,6 +718,9 @@ class MispEvent(MispBaseObject):
             pass
         for attr in self.attributes:
             event.append(attr.to_xml_object())
+        
+        for obj in self.objects:
+            event.appen(obj.to_xml_object())
 
         org = objectify.Element('Org')
         org.name = self.org

--- a/mispy/misp.py
+++ b/mispy/misp.py
@@ -720,7 +720,7 @@ class MispEvent(MispBaseObject):
             event.append(attr.to_xml_object())
         
         for obj in self.objects:
-            event.appen(obj.to_xml_object())
+            event.append(obj.to_xml_object())
 
         org = objectify.Element('Org')
         org.name = self.org

--- a/mispy/misp.py
+++ b/mispy/misp.py
@@ -387,6 +387,7 @@ class MispObject(MispBaseObject):
         for field in ['id', 'event_id', 'name', 'description', 'comment', 'timestamp']:
             val = getattr(xml_obj, field)
             setattr(obj, field, val)
+        obj.meta_category = getattr(xml_obj, "meta-category")
         
         attributes = []
         for attr in xml_obj.Attribute:
@@ -665,11 +666,12 @@ class MispEvent(MispBaseObject):
             # No attribute, no worries
             pass
         
-        objects = []
-        for cur_obj in obj.Object:
-            obj_obj = MispObject.from_xml_object(cur_obj)
-            objects.append(obj_obj)
-        event.objects.set(objects)
+        if hasattr(obj, "Object"):
+            objects = []
+            for cur_obj in obj.Object:
+                obj_obj = MispObject.from_xml_object(cur_obj)
+                objects.append(obj_obj)
+            event.objects.set(objects)
 
         try:
             tags = []


### PR DESCRIPTION
This PR implements a `MispObject` class to add support for the `<Object>` tag in Events.

`Event.from_xml_object()` was modified to parse the fields from the XML.

`Event.to_xml_object()` was also modified to support outputting the `Objects` back into XML.

Finally, there is a new test to check `MispObject.from_xml()` 